### PR TITLE
removed leading / on Reference js interop file instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Simplistic implementation of an infinite scroll component for Blazor.
 
 3. Reference js interop file:
    
-    Add `<script src="/_content/Sve.Blazor.InfiniteScroll/js/Observer.js"></script>` to your _Host.cshtml or your index.html
+    Add `<script src="_content/Sve.Blazor.InfiniteScroll/js/Observer.js"></script>` to your _Host.cshtml or your index.html
 
 ## Usage
 


### PR DESCRIPTION
updated readme to not include the leading / when including the js interop source. Blazor is unable to find the Observer.js file with the leading /